### PR TITLE
Fixes Mailjet message structure

### DIFF
--- a/supabase/functions/mailjet/index.ts
+++ b/supabase/functions/mailjet/index.ts
@@ -38,12 +38,11 @@ const handler = async (req: Request): Promise<Response> => {
     const body = {
       Messages: [
         {
-          FromEmail: senderEmail, 
-          FromName: "Laneta",     
+          From: { Email: senderEmail, Name: "Laneta" },
           To: [{ Email: email, Name: "Usuario" }],
           Subject: subject,
           HTMLPart: html,
-          TextPart: html.replace(/<[^>]*>/g, ""),
+          TextPart: html.replace(/<[^>]*>/g, ""), 
         },
       ],
     };


### PR DESCRIPTION
Updates the Mailjet message structure to align with the expected format.

- Corrects the `From` field to use the nested `Email` and `Name` properties instead of `FromEmail` and `FromName` directly. Following mailjet 3.1v documentation